### PR TITLE
cj50.h: add generic for String*

### DIFF
--- a/cj50.h
+++ b/cj50.h
@@ -1297,12 +1297,13 @@ cleanup:
              , Vec(utf8char)*: push_Vec_utf8char        \
              , Vec(char)*: push_Vec_char                \
              , Vec(int)*: push_Vec_int                  \
-             , Vec(Vec2(int))*: push_Vec_Vec2_int          \
-             , Vec(Vec2(float))*: push_Vec_Vec2_float          \
-             , Vec(Rect2(float))*: push_Vec_Rect2_float          \
-             , Vec(Vec2(double))*: push_Vec_Vec2_double          \
-             , Vec(float)*: push_Vec_float                \
-             , Vec(double)*: push_Vec_double                \
+             , Vec(Vec2(int))*: push_Vec_Vec2_int       \
+             , Vec(Vec2(float))*: push_Vec_Vec2_float   \
+             , Vec(Rect2(float))*: push_Vec_Rect2_float \
+             , Vec(Vec2(double))*: push_Vec_Vec2_double \
+             , Vec(float)*: push_Vec_float              \
+             , Vec(double)*: push_Vec_double            \
+             , String*: push_String                	\
         )(coll, val)
 
 


### PR DESCRIPTION
Hi,

This pull request adds a generic for `String*`.

I tested the change and it works with this basic example:

```c
#include <cj50.h>


Result(Unit, String) run(UNUSED slice(cstr) argv) {
    BEGIN_Result(Unit, String);

    String s = new_String();
    push(&s, 'H');
    println(&s);
    drop(s);

    RETURN_Ok(Unit(), cleanup);
cleanup:
    END_Result();
}

MAIN(run);
```

Running the binary results in the following:

```sh
[jgart@fedora ownproject]$ ./hello 
H
```